### PR TITLE
Work around incoming breaking changes in SLOPE

### DIFF
--- a/R/run_algorithm.R
+++ b/R/run_algorithm.R
@@ -43,12 +43,12 @@ run_atos <- function(X, y, groups, groupIDs, pen_slope, pen_gslope, x0, u, wt, n
     Xbeta = mult_fcn(X,z)
     fz = f(y, Xbeta, num_obs, crossprod_mat)
     grad_fz = mult_fcn(tX,f_grad(y, Xbeta, num_obs))
-    x = sortedL1Prox(x=z - (step_size * (u + (grad_fz))), lambda=pen_slope*step_size, method="stack")
+    x = sortedL1Prox(x=z - (step_size * (u + (grad_fz))), lambda=pen_slope*step_size)
     incr = x - z
     norm_incr = norm_vec(incr)
     if (norm_incr > 1e-7){
       for (it_ls in 1:max_iter_backtracking){ # Line search
-        x = sortedL1Prox(x=z - (step_size * (u + (grad_fz))), lambda=pen_slope*step_size, method="stack")
+        x = sortedL1Prox(x=z - (step_size * (u + (grad_fz))), lambda=pen_slope*step_size)
         incr = x - z
         norm_incr = norm_vec(incr)
         rhs = fz + crossprod_mat(grad_fz,incr) + (norm_incr ^ 2) / (2 * step_size)

--- a/R/utils.R
+++ b/R/utils.R
@@ -735,7 +735,7 @@ proxGroupSortedL1 <- function(y, lambda,group, group_id, num_groups) {
   }
 
   # get Euclidean norms of the solution vector
-  prox_norm <- sortedL1Prox(x=group_norm, lambda=lambda, method="stack")
+  prox_norm <- sortedL1Prox(x=group_norm, lambda=lambda)
 
   # compute the solution
   prox_solution <- rep(NA, length(y))

--- a/tests/testthat/test-slope.R
+++ b/tests/testthat/test-slope.R
@@ -7,14 +7,21 @@ test_that("solution reduces to slope when alpha=1, with no intercept or standard
   lambda=0.8
   groups=1:p
 
-  slope = SLOPE::SLOPE(X, y, family = "gaussian", alpha = lambda, q=0.1,intercept=FALSE,solver="admm",screen=FALSE,scale="none",center=FALSE)
-  
+  coef_ref <- c(
+    0, 0, 6.35351249775198, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -0.924615812626428,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -0.593341879455522, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0.0574674799067196, 0, 0, 0, 0, 0, 0, 0, 0
+  )
+
   sgs = fit_sgs(X=X,y=y, groups=groups, type="linear", lambda=lambda, alpha=1, vFDR=0.1, gFDR=0.1,intercept=FALSE,standardise="none")
   
-  slope_cost = sgs_convex_opt(X=X,y=y,beta=slope$coefficients,num_obs=n,gslope_seq=sgs$w_weights,slope_seq=sgs$v_weights,groups=groups, intercept=FALSE)
+  slope_cost = sgs_convex_opt(X=X,y=y,beta=coef_ref,num_obs=n,gslope_seq=sgs$w_weights,slope_seq=sgs$v_weights,groups=groups, intercept=FALSE)
   sgs_cost = sgs_convex_opt(X=X,y=y,beta=as.matrix(sgs$beta),num_obs=n,gslope_seq=sgs$w_weights,slope_seq=sgs$v_weights,groups=groups, intercept=FALSE)
 
-  expect_equivalent(as.matrix(slope$coefficients),
+  expect_equivalent(coef_ref,
     as.matrix(sgs$beta),
     tol = 1e-3
   )
@@ -31,14 +38,22 @@ test_that("solution reduces to slope when alpha=1, with intercept but no standar
   lambda=0.8
   groups=1:p
 
-  slope = SLOPE::SLOPE(X, y, family = "gaussian", alpha = lambda, q=0.1,intercept=TRUE,solver="admm",screen=FALSE,scale="none",center=TRUE)
-  
+  coef_ref <- c(
+    -0.591904300904075, 0, 0, 6.15570369828865, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    -0.855516332321258, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -0.597393440042509,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0.147583863629151, 0, 0, 0, 0, 0, 0,
+    0, 0
+  )
+
   sgs = fit_sgs(X=X,y=y, groups=groups, type="linear", lambda=lambda, alpha=1, vFDR=0.1, gFDR=0.1,intercept=TRUE,standardise="none")
   
-  slope_cost = sgs_convex_opt(X=X,y=y,beta=slope$coefficients,num_obs=n,gslope_seq=sgs$w_weights,slope_seq=sgs$v_weights,groups=groups, intercept=TRUE)
+  slope_cost = sgs_convex_opt(X=X,y=y,beta=coef_ref,num_obs=n,gslope_seq=sgs$w_weights,slope_seq=sgs$v_weights,groups=groups, intercept=TRUE)
   sgs_cost = sgs_convex_opt(X=X,y=y,beta=as.matrix(sgs$beta),num_obs=n,gslope_seq=sgs$w_weights,slope_seq=sgs$v_weights,groups=groups, intercept=TRUE)
 
-  expect_equivalent(as.matrix(slope$coefficients),
+  expect_equivalent(coef_ref,
     as.matrix(sgs$beta),
     tol = 1e-3
   )
@@ -55,14 +70,21 @@ test_that("solution reduces to slope when alpha=1, with no intercept but sd stan
   lambda=0.8
   groups=1:p
 
-  slope = SLOPE::SLOPE(X, y, family = "gaussian", alpha = lambda, q=0.1,intercept=FALSE,solver="admm",screen=FALSE,scale="sd",center=TRUE)
-  
+  coef_ref <- c(
+    0, 0, 6.62193929302955, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -0.794831421813014,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -0.446180314946519, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0.000446641410816172, 0, 0, 0, 0, 0, 0, 0, 0
+  )
+
   sgs = fit_sgs(X=X,y=y, groups=groups, type="linear", lambda=lambda, alpha=1, vFDR=0.1, gFDR=0.1,intercept=FALSE,standardise="sd")
   
-  slope_cost = sgs_convex_opt(X=X,y=y,beta=slope$coefficients,num_obs=n,gslope_seq=sgs$w_weights,slope_seq=sgs$v_weights,groups=groups, intercept=FALSE)
+  slope_cost = sgs_convex_opt(X=X,y=y,beta=coef_ref,num_obs=n,gslope_seq=sgs$w_weights,slope_seq=sgs$v_weights,groups=groups, intercept=FALSE)
   sgs_cost = sgs_convex_opt(X=X,y=y,beta=as.matrix(sgs$beta),num_obs=n,gslope_seq=sgs$w_weights,slope_seq=sgs$v_weights,groups=groups, intercept=FALSE)
 
-  expect_equivalent(as.matrix(slope$coefficients),
+  expect_equivalent(coef_ref,
     as.matrix(sgs$beta),
     tol = 1e-3
   )
@@ -79,14 +101,22 @@ test_that("solution reduces to slope when alpha=1, with no intercept but l1 stan
   lambda=0.8
   groups=1:p
 
-  slope = SLOPE::SLOPE(X, y, family = "gaussian", alpha = lambda, q=0.1,intercept=FALSE,solver="admm",screen=FALSE,scale="l1",center=TRUE)
-  
+  coef_ref <- c(
+    0, 0, 7.08023698435155, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1.32172932399327, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -0.72816894344401, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0.281886263999637, 0, 0, 0, 0.421166293233546, 0, 0, 0, 0, 0, 
+    0, 0, 0
+  )
+
   sgs = fit_sgs(X=X,y=y, groups=groups, type="linear", lambda=lambda, alpha=1, vFDR=0.1, gFDR=0.1,intercept=FALSE,standardise="l1")
   
-  slope_cost = sgs_convex_opt(X=X,y=y,beta=slope$coefficients,num_obs=n,gslope_seq=sgs$w_weights,slope_seq=sgs$v_weights,groups=groups, intercept=FALSE)
+  slope_cost = sgs_convex_opt(X=X,y=y,beta=coef_ref,num_obs=n,gslope_seq=sgs$w_weights,slope_seq=sgs$v_weights,groups=groups, intercept=FALSE)
   sgs_cost = sgs_convex_opt(X=X,y=y,beta=as.matrix(sgs$beta),num_obs=n,gslope_seq=sgs$w_weights,slope_seq=sgs$v_weights,groups=groups, intercept=FALSE)
 
-  expect_equivalent(as.matrix(slope$coefficients),
+  expect_equivalent(coef_ref,
     as.matrix(sgs$beta),
     tol = 1e-3
   )
@@ -103,14 +133,23 @@ test_that("solution reduces to slope when alpha=1, with no intercept but l2 stan
   lambda=0.8
   groups=1:p
 
-  slope = SLOPE::SLOPE(X, y, family = "gaussian", alpha = lambda, q=0.1,intercept=FALSE,solver="admm",screen=FALSE,scale="l2",center=TRUE)
-  
+  slope = SLOPE::SLOPE(X, y, family = "gaussian", alpha = lambda, q=0.1,intercept=FALSE,scale="l2",center=TRUE)
+
+  coef_ref <- c(
+    0, 0, 6.62199573208823, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -0.794796341616357,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -0.446206778892696, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0.000340786752155744, 0, 0, 0, 0, 0, 0, 0, 0
+  )
+ 
   sgs = fit_sgs(X=X,y=y, groups=groups, type="linear", lambda=lambda, alpha=1, vFDR=0.1, gFDR=0.1,intercept=FALSE,standardise="l2")
   
-  slope_cost = sgs_convex_opt(X=X,y=y,beta=slope$coefficients,num_obs=n,gslope_seq=sgs$w_weights,slope_seq=sgs$v_weights,groups=groups, intercept=FALSE)
+  slope_cost = sgs_convex_opt(X=X,y=y,beta=coef_ref,num_obs=n,gslope_seq=sgs$w_weights,slope_seq=sgs$v_weights,groups=groups, intercept=FALSE)
   sgs_cost = sgs_convex_opt(X=X,y=y,beta=as.matrix(sgs$beta),num_obs=n,gslope_seq=sgs$w_weights,slope_seq=sgs$v_weights,groups=groups, intercept=FALSE)
 
-  expect_equivalent(as.matrix(slope$coefficients),
+  expect_equivalent(coef_ref,
     as.matrix(sgs$beta),
     tol = 1e-3
   )
@@ -127,14 +166,21 @@ test_that("solution reduces to slope when alpha=1, with intercept and sd standar
   lambda=0.8
   groups=1:p
 
-  slope = SLOPE::SLOPE(X, y, family = "gaussian", alpha = lambda, q=0.1,intercept=TRUE,solver="admm",screen=FALSE,scale="sd",center=TRUE)
-  
+  coef_ref <- c(
+    -0.443697677962616, 0, 0, 6.621939698726, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -0.794830608447868,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -0.446179964202237, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0.000444025886934943, 0, 0, 0, 0, 0, 0, 0, 0
+  )
+ 
   sgs = fit_sgs(X=X,y=y, groups=groups, type="linear", lambda=lambda, alpha=1, vFDR=0.1, gFDR=0.1,intercept=TRUE,standardise="sd")
   
-  slope_cost = sgs_convex_opt(X=X,y=y,beta=slope$coefficients,num_obs=n,gslope_seq=sgs$w_weights,slope_seq=sgs$v_weights,groups=groups, intercept=TRUE)
+  slope_cost = sgs_convex_opt(X=X,y=y,beta=coef_ref,num_obs=n,gslope_seq=sgs$w_weights,slope_seq=sgs$v_weights,groups=groups, intercept=TRUE)
   sgs_cost = sgs_convex_opt(X=X,y=y,beta=as.matrix(sgs$beta),num_obs=n,gslope_seq=sgs$w_weights,slope_seq=sgs$v_weights,groups=groups, intercept=TRUE)
 
-  expect_equivalent(as.matrix(slope$coefficients),
+  expect_equivalent(coef_ref,
     as.matrix(sgs$beta),
     tol = 1e-3
   )
@@ -151,14 +197,22 @@ test_that("solution reduces to slope when alpha=1, with intercept and l1 standar
   lambda=0.8
   groups=1:p
 
-  slope = SLOPE::SLOPE(X, y, family = "gaussian", alpha = lambda, q=0.1,intercept=TRUE,solver="admm",screen=FALSE,scale="l1",center=TRUE)
+  coef_ref <- c(
+    -0.237185741459661, 0, 0, 7.08023698435156, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    -1.32172932399327, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -0.728168943444005,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0.281886263999636, 0, 0, 0, 0.421166293233551, 0,
+    0, 0, 0, 0, 0, 0, 0
+  )
   
   sgs = fit_sgs(X=X,y=y, groups=groups, type="linear", lambda=lambda, alpha=1, vFDR=0.1, gFDR=0.1,intercept=TRUE,standardise="l1")
   
-  slope_cost = sgs_convex_opt(X=X,y=y,beta=slope$coefficients,num_obs=n,gslope_seq=sgs$w_weights,slope_seq=sgs$v_weights,groups=groups, intercept=TRUE)
+  slope_cost = sgs_convex_opt(X=X,y=y,beta=coef_ref,num_obs=n,gslope_seq=sgs$w_weights,slope_seq=sgs$v_weights,groups=groups, intercept=TRUE)
   sgs_cost = sgs_convex_opt(X=X,y=y,beta=as.matrix(sgs$beta),num_obs=n,gslope_seq=sgs$w_weights,slope_seq=sgs$v_weights,groups=groups, intercept=TRUE)
 
-  expect_equivalent(as.matrix(slope$coefficients),
+  expect_equivalent(coef_ref,
     as.matrix(sgs$beta),
     tol = 1e-3
   )
@@ -175,14 +229,22 @@ test_that("solution reduces to slope when alpha=1, with intercept and l2 standar
   lambda=0.8
   groups=1:p
 
-  slope = SLOPE::SLOPE(X, y, family = "gaussian", alpha = lambda, q=0.1,intercept=TRUE,solver="admm",screen=FALSE,scale="l2",center=TRUE)
+  coef_ref <- c(
+    -0.443672029601005, 0, 0, 6.62199573208823, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    -0.794796341616357, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -0.446206778892693,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0.00034078675215286, 0, 0, 0, 0, 0, 0,
+    0, 0
+  )
   
   sgs = fit_sgs(X=X,y=y, groups=groups, type="linear", lambda=lambda, alpha=1, vFDR=0.1, gFDR=0.1,intercept=TRUE,standardise="l2")
   
-  slope_cost = sgs_convex_opt(X=X,y=y,beta=slope$coefficients,num_obs=n,gslope_seq=sgs$w_weights,slope_seq=sgs$v_weights,groups=groups, intercept=TRUE)
+  slope_cost = sgs_convex_opt(X=X,y=y,beta=coef_ref,num_obs=n,gslope_seq=sgs$w_weights,slope_seq=sgs$v_weights,groups=groups, intercept=TRUE)
   sgs_cost = sgs_convex_opt(X=X,y=y,beta=as.matrix(sgs$beta),num_obs=n,gslope_seq=sgs$w_weights,slope_seq=sgs$v_weights,groups=groups, intercept=TRUE)
 
-  expect_equivalent(as.matrix(slope$coefficients),
+  expect_equivalent(coef_ref,
     as.matrix(sgs$beta),
     tol = 1e-3
   )


### PR DESCRIPTION
`screen` and `solver = "admm"` will soon be deprecated, so drop them
from the tests. `coefficients` in the returned object will now also be a
list, so update the tests with fixed references instead.